### PR TITLE
Change `inertia_norm` from `RADIAL` to `BOTH`

### DIFF
--- a/src/em_gyre.fpp
+++ b/src/em_gyre.fpp
@@ -248,7 +248,7 @@ contains
 
     os_p = osc_par_t(x_ref=1._dp, &
                      outer_bound='JCD', &
-                     inertia_norm='RADIAL', &
+                     inertia_norm='BOTH', &
                      alpha_rht=1._DP)
 
     ! Rotation


### PR DESCRIPTION
The mode inertia in Ball & Gizon (2014) corresponds to `inertia_norm='BOTH'` rather than `'RADIAL'`. Local testing changed the example χ² in AMP2 from 1.393517... to 1.393483..., which is about the level I expected. The best-fitting mode frequencies differ by less than 5e-5. That's all the testing I did but is consistent with my expectations of it being a very small change.